### PR TITLE
Implement Clone trait into Credentials

### DIFF
--- a/src/credentials.rs
+++ b/src/credentials.rs
@@ -6,7 +6,7 @@ use smpl_jwt::RSAKey;
 
 use std::str::FromStr;
 
-#[derive(Serialize, Deserialize, Debug)]
+#[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct Credentials {
     #[serde(rename = "type")]
     t: String,


### PR DESCRIPTION
This PR implements `Clone` trait into `Credentials`, which becomes particularly handy when defining clients composed by this struct.

💃  