### PR TITLE
Add expire_in accessor method for Token

### DIFF
--- a/src/auth.rs
+++ b/src/auth.rs
@@ -90,6 +90,10 @@ impl Token {
     pub fn token_type(&self) -> &str {
         &self.token_type
     }
+    
+    pub fn expires_in(&self) -> u32 {
+        self.expires_in
+    }
 }
 
 impl FromStr for Token {


### PR DESCRIPTION
This PR adds `expires_in` accessor method to `auth::Token` to be able to retrieve its lifetime. 