### PR TITLE
Derive `Clone` trait for TokenErr and Scope

### DIFF
--- a/src/auth.rs
+++ b/src/auth.rs
@@ -47,7 +47,7 @@ impl fmt::Display for JwtClaims {
     }
 }
 
-#[derive(Serialize, Deserialize, Debug)]
+#[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct TokenErr {
     error: String,
     error_description: String

--- a/src/scopes.rs
+++ b/src/scopes.rs
@@ -2,6 +2,7 @@
 
 #![allow(dead_code)]
 
+#[derive(Clone, Debug)]
 pub enum Scope {
     Activity,
     AdexchangeBuyer,


### PR DESCRIPTION
Some public structs and enums are missing the trivial `Clone` trait, which means they cannot be used in other structs that need to be cloned. This adds the missing traits.