### PR TITLE
Add BigTableData and BigTableDataReadOnly scopes

### DIFF
--- a/src/scopes.rs
+++ b/src/scopes.rs
@@ -57,6 +57,8 @@ pub enum Scope {
     AppsOrder,
     AppsOrderReadOnly,
     AppState,
+    BigTableData,
+    BigTableDataReadOnly,
     BigQuery,
     BigQueryInsertdata,
     Blogger,
@@ -313,6 +315,10 @@ impl Scope {
             => String::from("https://www.googleapis.com/auth/apps.order.readonly"),
             Scope::AppState
             => String::from("https://www.googleapis.com/auth/appstate"),
+            Scope::BigTableData
+            => String::from("https://www.googleapis.com/auth/bigtable.data"),
+            Scope::BigTableDataReadOnly
+            => String::from("https://www.googleapis.com/auth/bigtable.data.readonly"),
             Scope::BigQuery
             => String::from("https://www.googleapis.com/auth/bigquery"),
             Scope::BigQueryInsertdata


### PR DESCRIPTION
Using `Scope::CloudPlatform` (https://github.com/durch/rust-bigtable/blob/17944dcaaa4a247e43229bfa8116c915dd85dbcd/src/utils.rs#L26) to read from BigTable is overly generous, we can use the BigTableData scopes instead once exposed here