### PR TITLE
add TokenFetcher struct for automatic token refresh

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,10 +21,11 @@ serde_json = "^1.0"
 time = "0.2.14"
 log = "0.4.8"
 smpl_jwt = "^0.5"
-reqwest = {version = "0.10.4", features = ["blocking", "json"]}
+reqwest = { version = "0.10.4", features = ["blocking", "json"] }
 futures = "0.3.4"
 simpl = "0.1.0"
-tokio = "^0.2"
+tokio = { version = "^0.2", features = ["macros"] }
 
 [dev-dependencies]
 doc-comment = "0.3.3"
+mockito = "^0.27.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,7 @@ name = "goauth"
 path = "src/lib.rs"
 
 [dependencies]
+arc-swap = "^0.4.7"
 serde = "^1.0"
 serde_derive = "^1.0"
 serde_json = "^1.0"

--- a/src/auth.rs
+++ b/src/auth.rs
@@ -67,7 +67,7 @@ impl Error for TokenErr {
     }
 }
 
-#[derive(Serialize, Deserialize, Debug, Clone)]
+#[derive(Eq, PartialEq, Serialize, Deserialize, Debug, Clone)]
 pub struct Token {
     access_token: String,
     token_type: String,

--- a/src/credentials.rs
+++ b/src/credentials.rs
@@ -15,7 +15,8 @@ pub struct Credentials {
     client_email: String,
     client_id: String,
     auth_uri: String,
-    token_uri: String,
+    // pub(crate) to this can be overriden in tests
+    pub(crate) token_uri: String,
     auth_provider_x509_cert_url: String,
     client_x509_cert_url: String
 }

--- a/src/fetcher.rs
+++ b/src/fetcher.rs
@@ -1,0 +1,102 @@
+//! Defines a `TokenFetcher` struct that will automatically refresh tokens
+//! at some configured time prior to the token's expiration.
+
+use crate::auth::{JwtClaims, Token};
+use crate::credentials::Credentials;
+use crate::{get_token_with_client, Result};
+
+use reqwest::Client;
+use smpl_jwt::Jwt;
+use time::{Duration, OffsetDateTime};
+
+/// A `TokenFetcher` stores a `Token` on first fetch and will continue returning
+/// that token until it needs to be refreshed, as determined by the token's
+/// `expires_in` field and the configured `refresh_buffer`.
+///
+/// Specifically on each token fetch request, it will check the current time
+/// against the expected time the currently stored token will expire. If it
+/// is within the `refresh_buffer` window, it will fetch a new token, store
+/// that (along with the new expired time), and return the new token.
+pub struct TokenFetcher {
+    client: Client,
+    jwt: Jwt<JwtClaims>,
+    credentials: Credentials,
+    token_state: Option<TokenState>,
+    refresh_buffer: Duration,
+}
+
+struct TokenState {
+    /// The currently stored token
+    token: Token,
+    /// The lower bound of the time at which the token needs to be refreshed
+    refresh_at: OffsetDateTime,
+}
+
+impl TokenFetcher {
+    pub fn new(
+        jwt: Jwt<JwtClaims>,
+        credentials: Credentials,
+        refresh_buffer: Duration
+    ) -> TokenFetcher {
+        TokenFetcher::with_client(Client::new(), jwt, credentials, refresh_buffer)
+    }
+
+    pub fn with_client(
+        client: Client,
+        jwt: Jwt<JwtClaims>,
+        credentials: Credentials,
+        refresh_buffer: Duration
+    ) -> TokenFetcher {
+        let token_state = None;
+
+        TokenFetcher {
+            client,
+            jwt,
+            credentials,
+            token_state,
+            refresh_buffer,
+        }
+    }
+
+    /// Returns a token if the token is still considered "valid" per the
+    /// currently stored token's `expires_in` field and the configured
+    /// `refresh_buffer`. If it is, return the stored token. If not,
+    /// fetch a new token, store it, and return the new token.
+    pub async fn fetch_token(&mut self) -> Result<Token> {
+        match &self.token_state {
+            // First time calling `fetch_token` since initialization, so fetch
+            // a token.
+            None => self.get_token().await,
+            Some(token_state) => {
+                let now = OffsetDateTime::now_utc();
+
+                if now >= token_state.refresh_at {
+                    // We have an existing token but it is time to refresh it
+                    self.get_token().await
+                } else {
+                    // We have an existing, valid token, so return immediately
+                    Ok(token_state.token.clone())
+                }
+            },
+        }
+    }
+
+    /// Refresh the token
+    async fn get_token(&mut self) -> Result<Token> {
+        let now = OffsetDateTime::now_utc();
+
+        let token = get_token_with_client(&self.client, &self.jwt, &self.credentials).await?;
+        let expires_in = Duration::new(token.expires_in().into(), 0);
+
+        assert!(expires_in >= self.refresh_buffer, "Received a token whose expires_in is less than the configured refresh buffer!");
+
+        let refresh_at = now + (expires_in - self.refresh_buffer);
+        let token_state = TokenState {
+            token: token.clone(),
+            refresh_at,
+        };
+
+        self.token_state.replace(token_state);
+        Ok(token)
+    }
+}

--- a/src/fetcher.rs
+++ b/src/fetcher.rs
@@ -237,7 +237,7 @@ mod tests {
         let mock = mock("POST", "/")
             .with_status(200)
             .with_body(json)
-            .expect(1) // we expect to be hit twice due to refresh
+            .expect(1) // we expect to be hit only once
             .create();
 
         // this should work

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,6 +7,7 @@ extern crate doc_comment;
 
 pub mod auth;
 pub mod credentials;
+pub mod fetcher;
 pub mod scopes;
 
 use auth::{JwtClaims, Token};
@@ -183,15 +184,28 @@ pub async fn get_token(
     jwt: &Jwt<JwtClaims>,
     credentials: &Credentials,
 ) -> Result<Token> {
+    let client = Client::new();
+
+    get_token_with_client(
+        &client,
+        jwt,
+        credentials
+    ).await
+}
+
+pub async fn get_token_with_client(
+    client: &Client,
+    jwt: &Jwt<JwtClaims>,
+    credentials: &Credentials,
+) -> Result<Token> {
     let final_jwt = jwt.finalize()?;
     let request_body = form_body(&final_jwt);
 
-    let client = Client::new();
     let response = client
         .post(&credentials.token_uri())
         .form(&request_body)
         .send().await?;
-    
+
     let token = response.json::<Token>().await?;
     Ok(token)
 }


### PR DESCRIPTION
Closes #12 .

- Add a `get_token_with_client` variant that allows clients to pass in their own `reqwest::Client`
- Modify `get_token` (and therefore `get_token_blocking` and friends) to call into `get_token_with_client`
- Add a `TokenFetcher` struct that will automatically refresh the token for each `fetch_token` call
    - There was some trickiness here to figure out when exactly to refresh. One choice in theory on the client side is to keep using the token until you get 403'd and refresh then, but that is tricky / complex to do in a library - those who want to do so can build their own using `get_token_with_client`. What I decided to do instead is to allow clients to specify a `refresh_buffer` and for each `fetch_token` request check "is `now()` >= <time we fetched token> + (<token expires_in> - <refresh_buffer>)"? If so, refresh.

**EDIT**: Figured out how to get tests in!

**EDIT 2**: I switched from using a mutable field to using `arc_swap::ArcSwap` since token refresh seems to be a perfect use case for that (often read, seldom updated). However this does incur an `arc-swap` dependency.. I can put this behind a feature flag if you don't want to incur this dependency, just LMK!

~~One open question for this PR is there is some slightly non-trivial logic here with when we decide to refresh or not refresh which I would like to test ideally. Doing so in the current design would require being able to hijack the `Token` response from the HTTP class so we can shove in custom `expires_in` values and see what happens. Anecdotally I have used the [mockito](https://docs.rs/mockito/0.27.0/mockito/) library, but only in contexts where I require clients to pass in a URL explicitly anyways so it is easy to pass in `mockito::server_url()` just in the tests and keep `mockito` as a `dev-dependencies`. In this case since the URL is dictated [on the user side](https://github.com/durch/rust-goauth/blob/master/src/lib.rs#L191) we would need to do the trick they mention in the docs with something like:~~

```rust
#[cfg(test)]
use mockito;

pub async fn get_token(
    jwt: &Jwt<JwtClaims>,
    credentials: &Credentials,
) -> Result<Token> {
    let final_jwt = jwt.finalize()?;
    let request_body = form_body(&final_jwt);

    #[cfg(not(test))]
    let url = credentials.token_uri();

    #[cfg(test)]
    let url = mockito::server_url();

    let client = Client::new();
    let response = client
        .post(&url)
        .form(&request_body)
        .send().await?;
    
    let token = response.json::<Token>().await?;
    Ok(token)
}
```

~~But this would require incurring a mockito dependency on all users which seems.. strange. Curious to get your take on this.~~