### PR TITLE
Forward auth errors to user on failed token fetch

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -206,8 +206,13 @@ pub async fn get_token_with_client(
         .form(&request_body)
         .send().await?;
 
-    let token = response.json::<Token>().await?;
-    Ok(token)
+    if response.status().is_success() {
+        let token = response.json::<Token>().await?;
+        Ok(token)
+    } else {
+        let token_err = response.json::<auth::TokenErr>().await?;
+        Err(GoErr::from(token_err))
+    }
 }
 
 #[cfg(test)]


### PR DESCRIPTION
Addresses #14 

Following the same instructions to reproduce from #14, the test fails with a Token-related error message

```
$ cargo test -- --nocapture get_token_blocking
...
stdout:
GoErr { description: Some("TokenErr: Invalid grant: account not found"), data: None, source: Some(Token(TokenErr { error: "invalid_grant", error_description: "Invalid grant: account not found" })) }
```

I'd like to add a couple test cases - one where auth always succeeds and another where it always fails (and we assert that the user gets the `TokenErr` response). But I'm not sure yet how to set this up - e.g. how do we make sure this library's credentials are valid for authenticating with Google? Do you know how to do that? (is `dummy_credentials_file_for_tests.json` meant to always be valid?)