### PR TITLE
Bumping time to 0.3

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ arc-swap = "1"
 serde = "^1"
 serde_derive = "1"
 serde_json = "1"
-time = "0.2"
+time = "0.3"
 log = "0.4"
 smpl_jwt = "0.6.1"
 reqwest = { version = "0.11", features = ["blocking", "json"] }


### PR DESCRIPTION
Little change in time between
```rust
use time::Duration;
// and
use time::duration::Duration;
```
Making the examples only compile with time `0.2`