### PR TITLE
Add malachite-ingestion scope for Google Chronicle.

### DIFF
--- a/src/scopes.rs
+++ b/src/scopes.rs
@@ -142,6 +142,7 @@ pub enum Scope {
     LoggingRead,
     LoggingWrite,
     M8Feeds,
+    MalachiteIngestion,
     ManufacturerCenter,
     Monitoring,
     MonitoringRead,
@@ -526,6 +527,9 @@ impl Scope {
             Scope::LoggingRead => String::from("https://www.googleapis.com/auth/logging.read"),
             Scope::LoggingWrite => String::from("https://www.googleapis.com/auth/logging.write"),
             Scope::M8Feeds => String::from("https://www.google.com/m8/feeds"),
+            Scope::MalachiteIngestion => {
+                String::from("https://www.googleapis.com/auth/malachite-ingestion")
+            }
             Scope::ManufacturerCenter => {
                 String::from("https://www.googleapis.com/auth/manufacturercenter")
             }


### PR DESCRIPTION
This adds a Scope for Google Chronicle - see [here](https://cloud.google.com/chronicle/docs/reference/ingestion-api#getting_api_authentication_credentials).

Signed-off-by: Stephen Wakely <fungus.humungus@gmail.com>